### PR TITLE
feat: add support for local terraform states

### DIFF
--- a/tfexec/terraform.go
+++ b/tfexec/terraform.go
@@ -111,6 +111,9 @@ type TerraformCLI interface {
 	// StatePush pushes a given State to remote.
 	StatePush(ctx context.Context, state *State, opts ...string) error
 
+	// StateWriteLocal saves the new state to a local state file.
+	StateWriteLocal(ctx context.Context, state *State) error
+
 	// WorkspaceNew creates a new workspace with name "workspace".
 	WorkspaceNew(ctx context.Context, workspace string, opts ...string) error
 

--- a/tfexec/terraform_state_local.go
+++ b/tfexec/terraform_state_local.go
@@ -1,0 +1,24 @@
+package tfexec
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// StateWriteLocal saves the new state to a local state file.
+func (c *terraformCLI) StateWriteLocal(_ context.Context, state *State) error {
+	localStateFile := "terraform.tfstate"
+	path := filepath.Join(c.Dir(), localStateFile)
+	if err := os.WriteFile(path, []byte(state.Bytes()), 0600); err != nil {
+		return fmt.Errorf("failed to write %s: %s", localStateFile, err)
+	}
+
+	tmpState, err := writeTempFile(state.Bytes())
+	defer os.Remove(tmpState.Name())
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/tfmigrate/migrator.go
+++ b/tfmigrate/migrator.go
@@ -23,7 +23,7 @@ type Migrator interface {
 
 // setupWorkDir is a common helper function to set up work dir and returns the
 // current state and a switch back function.
-func setupWorkDir(ctx context.Context, tf tfexec.TerraformCLI, workspace string, isBackendTerraformCloud bool, backendConfig []string, ignoreLegacyStateInitErr bool) (*tfexec.State, func() error, error) {
+func setupWorkDir(ctx context.Context, tf tfexec.TerraformCLI, workspace string, isBackendTerraformCloud bool, backendConfig []string, ignoreLegacyStateInitErr bool, isLocal bool) (*tfexec.State, func() error, error) {
 	// check if terraform command is available.
 	version, err := tf.Version(ctx)
 	if err != nil {
@@ -68,11 +68,18 @@ func setupWorkDir(ctx context.Context, tf tfexec.TerraformCLI, workspace string,
 	if err != nil {
 		return nil, nil, err
 	}
-	// override backend to local
-	log.Printf("[INFO] [migrator@%s] override backend to local\n", tf.Dir())
-	switchBackToRemoteFunc, err := tf.OverrideBackendToLocal(ctx, "_tfmigrate_override.tf", workspace, isBackendTerraformCloud, backendConfig, ignoreLegacyStateInitErr)
-	if err != nil {
-		return nil, nil, err
+	if !isLocal {
+		// override backend to local
+		log.Printf("[INFO] [migrator@%s] override backend to local\n", tf.Dir())
+		switchBackToRemoteFunc, err := tf.OverrideBackendToLocal(ctx, "_tfmigrate_override.tf", workspace, isBackendTerraformCloud, backendConfig, ignoreLegacyStateInitErr)
+		if err != nil {
+			return nil, nil, err
+		}
+		return currentState, switchBackToRemoteFunc, nil
+	}
+	switchBackToRemoteFunc := func() error {
+		log.Printf("[INFO] [executor@%s] nothing to override\n", tf.Dir())
+		return nil
 	}
 	return currentState, switchBackToRemoteFunc, nil
 }

--- a/tfmigrate/multi_state_migrator_test.go
+++ b/tfmigrate/multi_state_migrator_test.go
@@ -218,7 +218,7 @@ resource "null_resource" "qux" {}
 	}
 	o := &MigratorOption{}
 	force := false
-	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false)
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false, false, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)
@@ -331,7 +331,7 @@ resource "null_resource" "qux" {}
 	}
 	o := &MigratorOption{}
 	force := false
-	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, true, false)
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, true, false, false, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)
@@ -442,7 +442,7 @@ resource "null_resource" "baz" {}
 	}
 	o := &MigratorOption{}
 	force := false
-	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, true)
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, true, false, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)
@@ -552,7 +552,7 @@ resource "null_resource" "qux" {}
 	}
 	o := &MigratorOption{}
 	force := false
-	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, true, true)
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, true, true, false, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)
@@ -666,7 +666,7 @@ resource "null_resource" "qux" {}
 	}
 	o := &MigratorOption{}
 	force := false
-	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false)
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false, false, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)
@@ -785,7 +785,7 @@ resource "null_resource" "qux2" {}
 	o := &MigratorOption{}
 	o.PlanOut = "foo.tfplan"
 	force := true
-	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false)
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false, false, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)
@@ -1003,7 +1003,7 @@ resource "null_resource" "qux" {}
 	}
 	o := &MigratorOption{}
 	force := false
-	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false)
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false, false, false)
 
 	err := m.Plan(ctx)
 	if err == nil {
@@ -1058,7 +1058,7 @@ resource "null_resource" "qux" {}
 	}
 	o := &MigratorOption{}
 	force := false
-	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false)
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false, false, false)
 
 	err := m.Plan(ctx)
 	if err == nil {
@@ -1118,7 +1118,7 @@ resource "null_resource" "qux" {}
 	}
 	o := &MigratorOption{}
 	force := false
-	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false)
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false, false, false)
 
 	err := m.Plan(ctx)
 	if err == nil {

--- a/tfmigrate/multi_state_mv_action_test.go
+++ b/tfmigrate/multi_state_mv_action_test.go
@@ -64,7 +64,7 @@ resource "null_resource" "qux" {}
 	}
 	o := &MigratorOption{}
 	force := false
-	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false)
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false, false, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)

--- a/tfmigrate/multi_state_xmv_action_test.go
+++ b/tfmigrate/multi_state_xmv_action_test.go
@@ -63,7 +63,7 @@ resource "null_resource" "qux" {}
 	}
 	o := &MigratorOption{}
 	force := false
-	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false)
+	m := NewMultiStateMigrator(fromTf.Dir(), toTf.Dir(), fromWorkspace, toWorkspace, actions, o, force, false, false, false, false)
 	err = m.Plan(ctx)
 	if err != nil {
 		t.Fatalf("failed to run migrator plan: %s", err)

--- a/tfmigrate/state_migrator.go
+++ b/tfmigrate/state_migrator.go
@@ -123,7 +123,8 @@ func (m *StateMigrator) plan(ctx context.Context) (currentState *tfexec.State, e
 	}
 
 	// setup work dir.
-	currentState, switchBackToRemoteFunc, err := setupWorkDir(ctx, m.tf, m.workspace, m.o.IsBackendTerraformCloud, m.o.BackendConfig, ignoreLegacyStateInitErr)
+	// TODO: implement isLocal support
+	currentState, switchBackToRemoteFunc, err := setupWorkDir(ctx, m.tf, m.workspace, m.o.IsBackendTerraformCloud, m.o.BackendConfig, ignoreLegacyStateInitErr, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add `from_is_local` and `to_is_local` to multi state migrations to avoid error on `terraform state push` when the state wasn't in a remote backend.

- [x] Update structs and function calls
- [ ] Add tests.